### PR TITLE
feat: update go linter in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
           version: latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
           version: latest
+          skip-pkg-cache: true
 
   generate:
     runs-on: ubuntu-latest

--- a/examples/provider-install-verification/main.tf
+++ b/examples/provider-install-verification/main.tf
@@ -1,14 +1,14 @@
 terraform {
   required_providers {
     clickup = {
-        version = "~> 0.0.1"
-        source = "hashicorp.io/catdevman/clickup"
+      version = "~> 0.0.1"
+      source  = "hashicorp.io/catdevman/clickup"
     }
   }
 }
 
 variable "CLICKUP_API_KEY" {
-    type = string
+  type = string
 }
 
 provider "clickup" {
@@ -17,60 +17,60 @@ provider "clickup" {
 
 data "clickup_teams" "teams" {}
 
-data "clickup_usergroups" "groups"{}
+data "clickup_usergroups" "groups" {}
 
 data "clickup_spaces" "spaces" {
-    team_id = "9014024487"
+  team_id = "9014024487"
 }
 
 data "clickup_space" "space" {
-    space_id = "90140051562"
+  space_id = "90140051562"
 }
 
 data "clickup_folders" "folders" {
-    space_id = "90140051562"
+  space_id = "90140051562"
 }
 
 data "clickup_folder" "folder" {
-    folder_id = "90140096619"
+  folder_id = "90140096619"
 }
 
 data "clickup_lists" "lists" {
-    folder_id = "90140103670"
+  folder_id = "90140103670"
 }
 
-data "clickup_folderless_lists" "folderless_lists"{
-    space_id = data.clickup_space.space.space.id
+data "clickup_folderless_lists" "folderless_lists" {
+  space_id = data.clickup_space.space.space.id
 }
 
 output "outtie" {
-    value = data.clickup_teams.teams
+  value = data.clickup_teams.teams
 }
 
 output "outtie2" {
-    value = data.clickup_usergroups.groups
+  value = data.clickup_usergroups.groups
 }
 
 output "outtie3" {
-    value = data.clickup_spaces.spaces
+  value = data.clickup_spaces.spaces
 }
 
 output "outtie4" {
-    value = data.clickup_space.space
+  value = data.clickup_space.space
 }
 
 output "outtie5" {
-    value = data.clickup_folders.folders
+  value = data.clickup_folders.folders
 }
 
 output "outtie6" {
-    value = data.clickup_folder.folder
+  value = data.clickup_folder.folder
 }
 
 output "outtie7" {
-    value = data.clickup_lists.lists
+  value = data.clickup_lists.lists
 }
 
 output "outtie8" {
-    value = data.clickup_folderless_lists.folderless_lists
+  value = data.clickup_folderless_lists.folderless_lists
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,24 +2,3 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package provider
-
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-)
-
-// testAccProtoV6ProviderFactories are used to instantiate a provider during
-// acceptance testing. The factory function will be invoked for every Terraform
-// CLI command executed to create a provider server to which the CLI can
-// reattach.
-var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"clickup": providerserver.NewProtocol6WithError(New("test")()),
-}
-
-func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
-}

--- a/internal/service/folder/data_source.go
+++ b/internal/service/folder/data_source.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	// "github.com/hashicorp/terraform-plugin-log/tflog"
+	// "github.com/hashicorp/terraform-plugin-log/tflog".
 	"github.com/raksul/go-clickup/clickup"
 )
 

--- a/internal/service/folders/data_source.go
+++ b/internal/service/folders/data_source.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	// "github.com/hashicorp/terraform-plugin-log/tflog".
 	"github.com/raksul/go-clickup/clickup"
 )
 

--- a/internal/service/folders/data_source.go
+++ b/internal/service/folders/data_source.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	// "github.com/hashicorp/terraform-plugin-log/tflog"
+	// "github.com/hashicorp/terraform-plugin-log/tflog".
 	"github.com/raksul/go-clickup/clickup"
 )
 

--- a/internal/service/spaces/data_source.go
+++ b/internal/service/spaces/data_source.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	// "github.com/hashicorp/terraform-plugin-log/tflog"
+	// "github.com/hashicorp/terraform-plugin-log/tflog".
 	"github.com/raksul/go-clickup/clickup"
 )
 

--- a/internal/service/teams/data_source.go
+++ b/internal/service/teams/data_source.go
@@ -90,7 +90,7 @@ func convertTeamMembers(members []clickup.TeamMember) []ClickUpTeamMemberDataSou
 	if len(members) == 0 {
 		return []ClickUpTeamMemberDataSourceModel{}
 	}
-	result := make([]ClickUpTeamMemberDataSourceModel, len(members), len(members))
+	result := make([]ClickUpTeamMemberDataSourceModel, 0, len(members))
 
 	for _, member := range members {
 		mem := ClickUpTeamMemberDataSourceModel{
@@ -119,7 +119,7 @@ func convertTeamMembers(members []clickup.TeamMember) []ClickUpTeamMemberDataSou
 	return result
 }
 
-// FIXME: Figure out how to get ints into types.Int64Value so we don't need this struct to translate
+// FIXME: Figure out how to get ints into types.Int64Value so we don't need this struct to translate.
 func getTeamSeats(ctx context.Context, client *clickup.Client, teamId string) (ClickUpTeamSeatsSourceModel, error) {
 	s := ClickUpTeamSeatsSourceModel{}
 	req, err := client.NewRequest(http.MethodGet, fmt.Sprintf("team/%s/seats", teamId), nil)

--- a/internal/service/teams/data_source.go
+++ b/internal/service/teams/data_source.go
@@ -90,9 +90,9 @@ func convertTeamMembers(members []clickup.TeamMember) []ClickUpTeamMemberDataSou
 	if len(members) == 0 {
 		return []ClickUpTeamMemberDataSourceModel{}
 	}
-	result := make([]ClickUpTeamMemberDataSourceModel, 0, len(members))
+	result := make([]ClickUpTeamMemberDataSourceModel, len(members))
 
-	for _, member := range members {
+	for i, member := range members {
 		mem := ClickUpTeamMemberDataSourceModel{
 			User: ClickUpTeamUserDataSourceModel{
 				Id:             types.Int64Value(int64(member.User.ID)),
@@ -114,7 +114,7 @@ func convertTeamMembers(members []clickup.TeamMember) []ClickUpTeamMemberDataSou
 				Initials:       types.StringValue(member.InvitedBy.Initials),
 			},
 		}
-		result = append(result, mem)
+		result[i] = mem
 	}
 	return result
 }

--- a/internal/service/usergroups/data_source.go
+++ b/internal/service/usergroups/data_source.go
@@ -79,7 +79,7 @@ func (c *ClickUpUserGroupsDataSource) Read(ctx context.Context, req datasource.R
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func getMembers(ctx context.Context, members []clickup.GroupMember) []ClickUpUserGroupMemberSourceModel {
+func getMembers(_ context.Context, members []clickup.GroupMember) []ClickUpUserGroupMemberSourceModel {
 	mems := []ClickUpUserGroupMemberSourceModel{}
 
 	for _, m := range members {
@@ -97,7 +97,7 @@ func getMembers(ctx context.Context, members []clickup.GroupMember) []ClickUpUse
 	return mems
 }
 
-// TODO: Figure out why avatar comes back as any
-func getAvatar(ctx context.Context, avatar any) ClickUpUserGroupAvatarSourceModel {
+// TODO: Figure out why avatar comes back as any.
+func getAvatar(_ context.Context, avatar any) ClickUpUserGroupAvatarSourceModel {
 	return ClickUpUserGroupAvatarSourceModel{}
 }


### PR DESCRIPTION
Since my other branch is getting quite big, I thought I would split out some smaller PR's.

Here is one to make the lint go green. (it's mostly just running the auto-linter that CI uses locally)

Also: 

- use the skip-cache suggestion from [here](https://github.com/golangci/golangci-lint-action/issues/135#issuecomment-791775296)
- Upgrade golangci-lint-action to v4.0.0